### PR TITLE
Add support for actions based on Docker images

### DIFF
--- a/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
+++ b/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
@@ -66,6 +66,11 @@ public class ActionOptions {
         return overwrite;
     }
 
+    public ActionOptions image(final String image) {
+        actionPut.getExec().image(image);
+        return this;
+    }
+
     private long genWebActionSecureKey() {
         final SecureRandom random = new SecureRandom();
         random.setSeed(System.currentTimeMillis());


### PR DESCRIPTION
Previously, client didn't provide any way to update an action which
was based on a Docker image, since it didn't provide any way to
specify the target image. This was required for the API endpoint to
accept a request.

This commit fixes it by enabling to specify the Docker image, and thus
to work with such actions.