### PR TITLE
Complete support for web secure actions

### DIFF
--- a/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
+++ b/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
@@ -12,6 +12,7 @@ public class ActionOptions {
     private ActionPut actionPut = new ActionPut()
                                       .exec(new ActionExec());
     private boolean overwrite;
+    private long webSecureKey;
 
     public ActionOptions(final String name) {
         this.name = QualifiedName.qualifiedName(name);
@@ -51,10 +52,19 @@ public class ActionOptions {
 
     public ActionOptions webSecure(final boolean secure) {
         if (secure) {
-            putAnnotation("require-whisk-auth", genWebActionSecureKey());
+            putSecurityAnnotation(genWebActionSecureKey());
         }
         return this;
 
+    }
+
+    public ActionOptions webSecure(final long key) {
+        putSecurityAnnotation(key);
+        return this;
+    }
+
+    public long webSecureKey() {
+        return webSecureKey;
     }
 
     public ActionOptions overwrite(final boolean overwrite) {
@@ -75,6 +85,11 @@ public class ActionOptions {
             key += Long.MAX_VALUE;
         }
         return key;
+    }
+
+    private void putSecurityAnnotation(final long key) {
+        webSecureKey = key;
+        putAnnotation("require-whisk-auth", key);
     }
 
     private void putAnnotation(final String key, final Object value) {


### PR DESCRIPTION
Previously, support for the web-secure option of actions was partial. It
suffered from 2 flaws:
- it was not possible to specify the secret key. Thus the only way to
  create or update an action was always changing the key to a new random
  one. This made it impossible to include this client in an automated
  continuous deployment process.
- the client didn't provide any way to get the generated random key. This
  meant that user would have to trigger another operation to get details
  on the action to retrieve that key.

This commit fixes both of these limitations, enabling to have all core
behaviors for updating web secure actions.