### PR TITLE
Fix bug when declaring an action as web enabled

### DIFF
--- a/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
+++ b/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
@@ -43,7 +43,7 @@ public class ActionOptions {
 
     public ActionOptions web(final boolean webEnabled) {
         if (webEnabled) {
-            putAnnotation("web-export", "true");
+            putAnnotation("web-export", true);
         }
         return this;
     }


### PR DESCRIPTION
Previously, when setting the "web" parameter of an action to true,
a bug would have as consequence that action would not be reachable
over HTTP, but the update operation would not detect it.

This commit fixes it so that an action can reliably be declared
as web.