### PR TITLE
Add ability to specify memory limit for an action to update

### DIFF
--- a/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
+++ b/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
@@ -2,6 +2,7 @@ package org.projectodd.openwhisk;
 
 import org.projectodd.openwhisk.model.ActionExec;
 import org.projectodd.openwhisk.model.ActionExec.KindEnum;
+import org.projectodd.openwhisk.model.ActionLimits;
 import org.projectodd.openwhisk.model.ActionPut;
 import org.projectodd.openwhisk.model.KeyValue;
 
@@ -10,7 +11,8 @@ import java.security.SecureRandom;
 public class ActionOptions {
     private final QualifiedName name;
     private ActionPut actionPut = new ActionPut()
-                                      .exec(new ActionExec());
+                                      .exec(new ActionExec())
+                                      .limits(new ActionLimits());
     private boolean overwrite;
 
     public ActionOptions(final String name) {
@@ -75,6 +77,11 @@ public class ActionOptions {
             key += Long.MAX_VALUE;
         }
         return key;
+    }
+
+    public ActionOptions memory(final int memoryLimit) {
+        actionPut.getLimits().memory(memoryLimit);
+        return this;
     }
 
     private void putAnnotation(final String key, final Object value) {


### PR DESCRIPTION
Previously, client didn't enable to specify the memory limit when
updating an action. This made it impossible to rely on the client
solely for managing actions.

This commit fixes it by adding this ability.