### PR TITLE
Tune default action execution time limit to CLI default

### DIFF
--- a/client/src/main/resources/apiv1swagger.json
+++ b/client/src/main/resources/apiv1swagger.json
@@ -1333,7 +1333,7 @@
                 "timeout": {
                     "type": "integer",
                     "format": "int32",
-                    "default": 30000
+                    "default": 60000
                 },
                 "memory": {
                     "type": "integer",


### PR DESCRIPTION
Previously, default execution time limit was set to 30 seconds
when updating an action and not specifying it. This was at odds
with the wsk CLI, whose default is 60 seconds. This called for
problems since users were unlikely to check it, and were thus
likely to end up with a lower time limit than they thought.

This commit fixes it.