### PR TITLE
Add support for timeout limit parameter

### DIFF
--- a/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
+++ b/client/src/main/java/org/projectodd/openwhisk/ActionOptions.java
@@ -77,6 +77,11 @@ public class ActionOptions {
         return key;
     }
 
+    public ActionOptions timeout(final int timeoutLimit) {
+        actionPut.getLimits().timeout(timeoutLimit);
+        return this;
+    }
+
     private void putAnnotation(final String key, final Object value) {
         final KeyValue annotations = new KeyValue();
         annotations.put("key", key);


### PR DESCRIPTION
Previously, it was impossible to use this client to update or
create an action with a different timeout than the default.
Worse than that, using this client meant that timeout was
reset to default each time an action was updated.

This commit fixes this limitation by adding support for
custom timeout.